### PR TITLE
TextFieldに検索ワードを入れて検索するとクラッシュする問題を修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/detail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/detail/RepositoryDetailFragment.kt
@@ -31,10 +31,11 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
         _binding = FragmentRepositoryDetailBinding.bind(view)
 
         var repository = args.repository
+        val languageWithPrefix = context?.getString(R.string.written_language, repository.language)
 
         binding.ownerIconView.load(repository.ownerIconUrl)
         binding.nameView.text = repository.name;
-        binding.languageView.text = repository.language;
+        binding.languageView.text = languageWithPrefix;
         binding.starsView.text = "${repository.stargazersCount} stars";
         binding.watchersView.text = "${repository.watchersCount} watchers";
         binding.forksView.text = "${repository.forksCount} forks";

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryFragment.kt
@@ -45,9 +45,7 @@ class SearchRepositoryFragment : Fragment(R.layout.fragment_search_repository) {
         binding.searchInputText.setOnEditorActionListener { editText, action, _ ->
             if (action == EditorInfo.IME_ACTION_SEARCH) {
                 editText.text.toString().let {
-                    Log.d("debug", "呼ばれたよ1")
                     viewModel.searchResults(it).apply {
-                        Log.d("debug", "呼ばれたよ3")
                         adapter.submitList(this)
                     }
                 }
@@ -94,6 +92,7 @@ class CustomAdapter(private val itemClickListener: OnItemClickListener, ) : List
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        Log.d("debug", "call onBindViewHolder()")
     	val item = getItem(position)
         (holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView).text = item.name
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryFragment.kt
@@ -92,7 +92,6 @@ class CustomAdapter(private val itemClickListener: OnItemClickListener, ) : List
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        Log.d("debug", "call onBindViewHolder()")
     	val item = getItem(position)
         (holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView).text = item.name
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryViewModel.kt
@@ -23,14 +23,11 @@ import java.util.*
 /**
  * GitHubのリポジトリ検索結果を保持する ViewModel
  */
-class SearchRepositoryViewModel(
-    val context: Context
-) : ViewModel() {
+class SearchRepositoryViewModel() : ViewModel() {
 
     // 検索結果
     fun searchResults(inputText: String): List<Repository> = runBlocking {
         val client = HttpClient(Android)
-        Log.d("debug", "呼ばれたよ2")
 
         return@runBlocking GlobalScope.async {
             val response: HttpResponse = client?.get("https://api.github.com/search/repositories") {
@@ -59,7 +56,7 @@ class SearchRepositoryViewModel(
                     Repository(
                         name = name,
                         ownerIconUrl = ownerIconUrl,
-                        language = context.getString(R.string.written_language, language),
+                        language = language,
                         stargazersCount = stargazersCount,
                         watchersCount = watchersCount,
                         forksCount = forksCount,


### PR DESCRIPTION
## 変更内容
- ViewModelのcontextを使ったプライマリコンストラクタを廃止し、R.stringの付与はFragmentで行うようにした

## 動作確認
- 検索ワードを入れて検索してもクラッシュしないこと（リストが表示されること）
- 詳細画面に記載された言語テキストの先頭に`R.string.written_language`が付与されていること

## 補足

### 不具合事象

TextFieldに検索ワードを入れて検索すると下記の箇所でクラッシュする

```kotlin
// SearchRepositoryFragment.kt
// 48行目

binding.searchInputText.setOnEditorActionListener { editText, action, _ ->
    if (action == EditorInfo.IME_ACTION_SEARCH) {
        editText.text.toString().let {
            viewModel.searchResults(it).apply {   // ここでクラッシュする
                adapter.submitList(this)
            }
        }
        return@setOnEditorActionListener true
     }
     return@setOnEditorActionListener false
}
```

クラッシュログ
<img width="1406" alt="スクリーンショット 2023-06-27 0 40 10" src="https://github.com/shusuke0812/android-engineer-codecheck/assets/33107697/4317bccf-387c-4925-a225-8d7f136cf142">
<img width="1668" alt="スクリーンショット 2023-06-27 0 40 26" src="https://github.com/shusuke0812/android-engineer-codecheck/assets/33107697/51cee34e-0a5d-48dd-9106-4a0cff2e50e0">

### 原因

- SearchViewModel(contex: Context): ViewModel() {} とプライマリコンストラクタが設定されている（引数contextがある）が、Fragment内で行なっているSearchVMの初期化に `by ViewModels()` が使用されていることが原因
- 引数contextを渡して初期化する必要がある（例：[VMFactoryを使う](https://qiita.com/cozyk100/items/f9879ca4611d3b5137ad#viewmodel%E3%81%AB%E5%BC%95%E6%95%B0%E3%81%8C%E3%81%82%E3%82%8B%E5%A0%B4%E5%90%88)）

### 対策
- SearchViewModelにはプライマリコンストラクタを使用しないようにした
- 理由は、Activity/Fragmentに比べてライフサイクルが長くなるVMにcontextを保持させるとメモリリークが発生する可能性があるため（[参考](https://developer.android.com/topic/libraries/architecture/viewmodel?hl=ja#:~:text=%C2%A0%20%C2%A0%20%7D%0A%7D-,%E6%B3%A8%E6%84%8F,-%3A%20ViewModel%20%E3%81%A7%E3%81%AF)）
- contextはR.stringを取得するために使用していたので、R.stringの設定はFragmentで行うようにした
