### PR TITLE
TopActivityにあるlastSearchDateをSearchVMに移行

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/TopActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/TopActivity.kt
@@ -8,8 +8,4 @@ import jp.co.yumemi.android.code_check.R
 import java.util.*
 
 class TopActivity : AppCompatActivity(R.layout.activity_top) {
-
-    companion object {
-        lateinit var lastSearchDate: Date
-    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/detail/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/detail/RepositoryDetailFragment.kt
@@ -10,8 +10,8 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
 import jp.co.yumemi.android.code_check.R
-import jp.co.yumemi.android.code_check.screen.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryDetailBinding
+import jp.co.yumemi.android.code_check.screen.search.SearchRepositoryViewModel
 
 /**
  * GitHubのリポジトリ詳細を表示する Fragment
@@ -25,7 +25,7 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        Log.d("検索した日時", lastSearchDate.toString())
+        Log.d("debug", "lastSearchDate=" + SearchRepositoryViewModel.lastSearchDate)
 
         _binding = FragmentRepositoryDetailBinding.bind(view)
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/screen/search/SearchRepositoryViewModel.kt
@@ -9,10 +9,9 @@ import androidx.lifecycle.viewModelScope
 import io.ktor.utils.io.errors.IOException
 import jp.co.yumemi.android.code_check.model.Repository
 import jp.co.yumemi.android.code_check.repository.GitHubSearchRepository
-import jp.co.yumemi.android.code_check.screen.TopActivity.Companion.lastSearchDate
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
-import java.util.*
+import java.util.Date
 
 interface SearchRepositoryViewModelDelegate {
     fun didSuccessSearchRepositories(items: List<Repository>?)
@@ -26,14 +25,19 @@ class SearchRepositoryViewModel(
     var delegate: SearchRepositoryViewModelDelegate? = null,
     private val repository: GitHubSearchRepository = GitHubSearchRepository()
 ) : ViewModel() {
+    companion object {
+        val lastSearchDate: Date get() { return _lastSearchDate }
+        private var _lastSearchDate: Date = Date()
+    }
+
     fun searchRepositories(inputText: String) {
         viewModelScope.launch {
             try {
                 val response = repository.getRepositories(inputText = inputText)
                 if (response.isSuccessful) {
                     val items = response.body()?.items
+                    _lastSearchDate = Date()
                     delegate?.didSuccessSearchRepositories(items = items)
-                    lastSearchDate = Date()
                     Log.d("debug", "items=$items")
                 } else {
                     delegate?.didFailSearchRepositories()


### PR DESCRIPTION
## 変更内容
- 標記の通り

## 動作確認
- 検索後にlastSearchDateが保存され、DetailFragment遷移後にLog出力されること
- lastSearchDateに別のDateを代入しようとするとビルドエラーになること

## 補足
<!-- 調べたことをまとめる -->
特になし